### PR TITLE
ipa-pta.conf workaround for LLVM 15+

### DIFF
--- a/sys-config/ltoize/files/package.cflags/ipa-pta.conf
+++ b/sys-config/ltoize/files/package.cflags/ipa-pta.conf
@@ -26,4 +26,5 @@ mail-client/thunderbird *FLAGS-="${IPAPTA}" # ICE with GCC 10.2.0 (seen with thu
 >=media-libs/mesa-21.1.0 *FLAGS-="${IPAPTA}" # Segfault with vulkan
 x11-base/xwayland *FLAGS-="${IPAPTA}" # SIGABRT when querying for GLX information
 >=dev-vcs/git-2.32.0 *FLAGS-="${IPAPTA}" # Segfault in git fetch with GCC < 11.3.0
+>=sys-devel/llvm-15.0.7 *FLAGS-="${IPAPTA}" # Failure while generating code from target descriptions with TableGen
 # END: -fipa-pta workarounds


### PR DESCRIPTION
Copied from: https://github.com/InBetweenNames/gentooLTO/pull/886

Title: sys-devel/llvm: -fipa-pta workaround for LLVM. Fixes https://github.com/InBetweenNames/gentooLTO/issues/881 although not only does LLVM 16 not compile with it, but at least 15.0.7-r3

The failure happens always while generating code for target devices with TableGen (calls to /var/tmp/portage/sys-devel/llvm-{version}/work/{currently compiling ABI}/bin/llvm-tblgen).